### PR TITLE
Fix refresh behavior

### DIFF
--- a/BeatSaverUpdater/UI/UpdateButton.cs
+++ b/BeatSaverUpdater/UI/UpdateButton.cs
@@ -185,7 +185,7 @@ namespace BeatSaverUpdater.UI
             if (downloadedLevelHash != null)
             {
                 SongCore.Loader.SongsLoadedEvent += OnSongsLoaded;
-                SongCore.Loader.Instance.RefreshSongs(false);
+                SongCore.Loader.Instance.RefreshSongs(true);
             }
         }
 


### PR DESCRIPTION
If you only do a soft reload, hashes aren't updated. So the level keeps the same `levelID` and people might end up submitting "cheated" scores. 